### PR TITLE
Replace accordion-toggle by a span to be able to select

### DIFF
--- a/Resources/css/styles.css
+++ b/Resources/css/styles.css
@@ -12,7 +12,7 @@
     padding-right: 3px;
 }
 
-.ladybug .accordion-heading a {
+.ladybug .accordion-heading span {
     color: #000;
     font-weight: bold;
 }

--- a/View/Html/_base.html.twig
+++ b/View/Html/_base.html.twig
@@ -3,7 +3,7 @@
 <div class="accordion-group">
 
     <div class="accordion-heading">
-        <a class="accordion-toggle {% block type_icon %}{% endblock %}" data-toggle="collapse" data-parent="#subb" href="#c{{ var.id }}">
+        <span class="accordion-toggle {% block type_icon %}{% endblock %}" data-toggle="collapse" data-parent="#subb" href="#c{{ var.id }}">
             <span class="array_key">
                 {% if visibility is not null %}
                     <span class="label {{ m.visibility_color(visibility) }}">
@@ -20,7 +20,7 @@
             {% endif %}
 
             {% block header_extra %}{% endblock %}
-        </a>
+        </span>
     </div>
 
     {% if composed %}

--- a/View/Html/_macros.html.twig
+++ b/View/Html/_macros.html.twig
@@ -68,7 +68,7 @@
 {% set id = random(1000) %}
     <div class="accordion-group">
         <div class="accordion-heading">
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#subb" href="#c{{ id }}">
+            <span class="accordion-toggle" data-toggle="collapse" data-parent="#subb" href="#c{{ id }}">
                 <span class="label {{ _self.visibility_color(method.visibility) }}">
                     <i class="icon-eye-open icon-white"></i>
                 </span>
@@ -87,7 +87,7 @@
                 {% endfor %}{% endspaceless %})
                 </span>
 
-            </a>
+            </span>
         </div>
         {% if method.shortDescription is not empty %}
             <div id="c{{ id }}" class="accordion-body collapse">

--- a/View/Html/object.html.twig
+++ b/View/Html/object.html.twig
@@ -25,7 +25,7 @@
 
     <div class="accordion-group">
         <div class="accordion-heading">
-            <a class="accordion-toggle" data-toggle="collapse" href="#object_data_{{ var.id }}">
+            <span class="accordion-toggle" data-toggle="collapse" href="#object_data_{{ var.id }}">
 
                 <span>Properties</span>
 
@@ -35,7 +35,7 @@
                     <span class="label label-important">{{ var.privatePropertiesNumber }}</span>
                 </span>
 
-            </a>
+            </span>
         </div>
         <div id="object_data_{{ var.id }}" class="accordion-body collapse {% if expanded %}in{% endif %}">
             <div class="accordion-inner">
@@ -58,9 +58,9 @@
     {% if var.classFile is not empty %}
     <div class="accordion-group">
         <div class="accordion-heading">
-            <a class="accordion-toggle" data-toggle="collapse" {#data-parent="#c{{ var.id }}"#} href="#object_info_{{ var.id }}">
+            <span class="accordion-toggle" data-toggle="collapse" {#data-parent="#c{{ var.id }}"#} href="#object_info_{{ var.id }}">
                 Class info
-            </a>
+            </span>
         </div>
         <div id="object_info_{{ var.id }}" class="accordion-body collapse {% if expanded %}in{% endif %}">
             <div class="accordion-inner">
@@ -91,12 +91,12 @@
     {% if var.classConstants is not empty %}
     <div class="accordion-group">
         <div class="accordion-heading">
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#c{{ var.id }}" href="#object_constants_{{ var.id }}">
+            <span class="accordion-toggle" data-toggle="collapse" data-parent="#c{{ var.id }}" href="#object_constants_{{ var.id }}">
                 <span>Class constants</span>
                 <span class="pull-right">
                     <span class="label label-inverse">{{ var.classConstants|length }}</span>
                 </span>
-            </a>
+            </span>
         </div>
         <div id="object_constants_{{ var.id }}" class="accordion-body collapse {% if expanded %}in{% endif %}">
             <div class="accordion-inner">
@@ -112,14 +112,14 @@
     {% if var.classMethods is not empty %}
     <div class="accordion-group">
         <div class="accordion-heading">
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#c{{ var.id }}" href="#object_methods_{{ var.id }}">
+            <span class="accordion-toggle" data-toggle="collapse" data-parent="#c{{ var.id }}" href="#object_methods_{{ var.id }}">
                 <span>Methods</span>
                 <span class="pull-right">
                     <span class="label label-success">{{ var.publicMethodsNumber }}</span>
                     <span class="label label-warning">{{ var.protectedMethodsNumber }}</span>
                     <span class="label label-important">{{ var.privateMethodsNumber }}</span>
                 </span>
-            </a>
+            </span>
         </div>
         <div id="object_methods_{{ var.id }}" class="accordion-body collapse {% if expanded %}in{% endif %}">
             <div class="accordion-inner">


### PR DESCRIPTION
Most of the time we need to select text in dumps.
Browser doesn't allow to select text in a <a> node so i replace the <a> nodes in accordion-toggle by span to be able to select text.
